### PR TITLE
Add normalized threshold intensity

### DIFF
--- a/src/drtvam/optimize.py
+++ b/src/drtvam/optimize.py
@@ -305,7 +305,10 @@ def optimize(config):
     efficiency = np.sum(normalized_array / normalized_array.size)
     print("Pattern efficiency {:.4f}".format(efficiency))
 
-    save_histogram(vol_final, target, os.path.join(output, "histogram.png"), efficiency)
+    max_intensity_pattern = np.max(imgs_final.numpy())
+
+    save_histogram(vol_final, target, os.path.join(output, "histogram.png"),
+                   efficiency, vol_final / max_intensity_pattern)
 
     return vol_final
 

--- a/src/drtvam/utils.py
+++ b/src/drtvam/utils.py
@@ -69,7 +69,7 @@ def save_histogram(vol, target, filename, efficiency, vol_normalized_peak_intens
     # meaning, if the best_threshold_normalized is a factor of 2 smaller to
     # another optimization with different parameters, this means we need a
     # factor of 2 less printing time.
-    thresholds_normalized = np.linspace(0, np.max(vol / vol_normalized_peak_intensity), 1000)
+    thresholds_normalized = np.linspace(0, np.max(vol_normalized_peak_intensity), 1000)
     ious_normalized = [iou_loss(vol_normalized_peak_intensity, target, t)[0] for t in thresholds_normalized]
     iou_normalized = max(ious_normalized)
     best_threshold_normalized = np.argmax(np.array(ious_normalized))

--- a/src/drtvam/utils.py
+++ b/src/drtvam/utils.py
@@ -44,7 +44,7 @@ def save_vol(vol, path):
     bmp = mi.Bitmap(mi.TensorXf(reshape_grid(vol)))
     bmp.write(path)
 
-def save_histogram(vol, target, filename, efficiency):
+def save_histogram(vol, target, filename, efficiency, vol_normalized_peak_intensity):
     fig = plt.figure(figsize=(10, 5))
     obj_mask = target.numpy().flatten() > 0.
 
@@ -59,11 +59,25 @@ def save_histogram(vol, target, filename, efficiency):
     ious = [iou_loss(vol, target, t)[0] for t in thresholds]
     iou = max(ious)
     best_threshold = np.argmax(np.array(ious))
-    print("best IoU: {:.4f}".format(iou))
-    print("best threshold: {:4f}".format(thresholds[best_threshold]))
+    print("Best IoU: {:.4f}".format(iou))
+    print("Best threshold: {:4f}".format(thresholds[best_threshold]))
+
+
+    # depending on the loss function the maximum pixel might be different
+    # With a DMD in practice, this means the real printing time is different
+    # with the best_threshold_normalized we know the absolute scaling
+    # meaning, if the best_threshold_normalized is a factor of 2 smaller to
+    # another optimization with different parameters, this means we need a
+    # factor of 2 less printing time.
+    thresholds_normalized = np.linspace(0, np.max(vol / vol_normalized_peak_intensity), 1000)
+    ious_normalized = [iou_loss(vol_normalized_peak_intensity, target, t)[0] for t in thresholds_normalized]
+    iou_normalized = max(ious_normalized)
+    best_threshold_normalized = np.argmax(np.array(ious_normalized))
+    print("Best normalized threshold: {:4f}".format(thresholds_normalized[best_threshold_normalized]))
 
     plt.xlim([0, 1.2])
-    plt.title("pattern energy efficiency = {:.4f}, IoU = {:.4f} at threshold = {:.3f}".format(efficiency, iou, thresholds[best_threshold]))
+    plt.title("pattern energy efficiency = {:.4f}, IoU = {:.4f} at threshold = {:.3f}, normalized threshold = {:.3f}".\
+              format(efficiency, iou, thresholds[best_threshold], thresholds_normalized[best_threshold_normalized]))
     plt.yscale('log')
     plt.ylabel("# Voxels")
     plt.xlabel("Received dose")


### PR DESCRIPTION
If we change the loss function (such as sparsity) the brightest pixel will change.
In practice the DMD always normalizes to the brightest pixel.

With the normalized_threshold we can estimate printing time better.

If the old `normalized_threshold = 0.25` and the new one is ` normalized_threshold = 0.1` we can conclude that we need a factor of 2.5 less printing time. 